### PR TITLE
Added a workflow to auto deploy dashboard image

### DIFF
--- a/.github/workflows/dashboard_image.yml
+++ b/.github/workflows/dashboard_image.yml
@@ -1,0 +1,38 @@
+name: Push the dashboard image to AWS ECR Repo
+
+on:
+  pull_request:
+    types:
+      - closed
+
+  workflow_dispatch:
+
+jobs:
+  Build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push docker image to Amazon ECR
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ secrets.DASHBOARD_REPO_NAME }} ### CHANGE REPO NAME
+          IMAGE_TAG: latest
+          ### CHANGE FOLDER LOCATION
+        run: |
+          cd dashboard
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/pipeline_image.yml
+++ b/.github/workflows/pipeline_image.yml
@@ -1,4 +1,4 @@
-name: Push the Docker image to AWS ECR Repo
+name: Push the pipeline image to AWS ECR Repo
 
 on:
   pull_request:

--- a/.github/workflows/pipeline_image.yml
+++ b/.github/workflows/pipeline_image.yml
@@ -29,8 +29,9 @@ jobs:
       - name: Build, tag, and push docker image to Amazon ECR
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: ${{ secrets.ETL_REPO_NAME }}
+          REPOSITORY: ${{ secrets.ETL_REPO_NAME }} ### CHANGE REPO NAME
           IMAGE_TAG: latest
+          ### CHANGE FOLDER LOCATION
         run: |
           cd pipeline
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .

--- a/.github/workflows/plant_sns_image.yml
+++ b/.github/workflows/plant_sns_image.yml
@@ -1,0 +1,38 @@
+name: Push the plant sns image to AWS ECR Repo
+
+on:
+  pull_request:
+    types:
+      - closed
+
+  workflow_dispatch:
+
+jobs:
+  Build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push docker image to Amazon ECR
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ secrets.PLANT_READING_REPO_NAME }} ### CHANGE REPO NAME
+          IMAGE_TAG: latest
+          ### CHANGE FOLDER LOCATION
+        run: |
+          cd sns_trigger_lambda
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG


### PR DESCRIPTION
Added a workflow to auto deploy dashboard image on merging a pull request. This means each new merge of python code will update the latest image in the dashboard ECR.

Closes #124 - make a dashboard image push to ECR action.